### PR TITLE
TimeValue serialization using getStringRep()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch</artifactId>
-    <version>1.4.1-rest-1.0.30-SNAPSHOT</version>
+    <version>1.4.1-rest-1.0.31-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Elasticsearch - Open Source, Distributed, RESTful Search Engine</description>
     <inceptionYear>2009</inceptionYear>

--- a/src/main/java/org/elasticsearch/common/unit/TimeValue.java
+++ b/src/main/java/org/elasticsearch/common/unit/TimeValue.java
@@ -225,6 +225,28 @@ public class TimeValue implements Serializable, Streamable {
         return Strings.format1Decimals(value, suffix);
     }
 
+    public String getStringRep() {
+        String duration = Long.toString(this.duration);
+        switch (timeUnit) {
+            case NANOSECONDS:
+                return duration + "nanos";
+            case MICROSECONDS:
+                return duration + "micros";
+            case MILLISECONDS:
+                return duration + "ms";
+            case SECONDS:
+                return duration + "s";
+            case MINUTES:
+                return duration + "m";
+            case HOURS:
+                return duration + "h";
+            case DAYS:
+                return duration + "d";
+            default:
+                throw new IllegalArgumentException("unknown time unit: " + timeUnit.name());
+        }
+    }
+
     public static TimeValue parseTimeValue(String sValue, TimeValue defaultValue) {
         if (sValue == null) {
             return defaultValue;


### PR DESCRIPTION
ES5 onwards unit is mandatory along with time. 
Application logic should make sure time value is fed in query as expected.  
This code adds support to serialize TimeValue with time unit.